### PR TITLE
fix: help message command

### DIFF
--- a/src/utils/validateArgs.go
+++ b/src/utils/validateArgs.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"log"
+	"os"
 )
 
 func usage() {
@@ -24,7 +25,7 @@ func ValidateArgs(args []string) {
 
 	if firstArg == "help" {
 		usage()
-		return
+		os.Exit(0)
 	}
 
 	if firstArg == "delete" {


### PR DESCRIPTION
## Context

This was causing errors when running `climb help` as it would allow an early non-fatal exit from `validateArgs()` while allowing only one argument, which then fails later in cli.Cmd() when it expects at least 2 validated arguments.

By exiting with code 0 instead of an early return, we can ensure that it does not run any other code that relies on validated arguments.