### PR TITLE
fix: typo && cleanup

### DIFF
--- a/src/execCmd/createOrUpdate.go
+++ b/src/execCmd/createOrUpdate.go
@@ -51,8 +51,6 @@ func installToLocalBin(pathToBin string, isUpdate bool, dryRun bool) {
 func CreateOrUpdate(alias string, pathToBin string, canOverrideExisting bool, dryRun bool) {
 	validatePathToBin(pathToBin)
 
-	var newPath = "user/local/bin/" + alias
-
 	if utils.AliasExists(alias) {
 		if canOverrideExisting == true {
 			// Update alias for new bin
@@ -69,7 +67,7 @@ func CreateOrUpdate(alias string, pathToBin string, canOverrideExisting bool, dr
 		}
 	} else if canOverrideExisting == false {
 		// Create new alias for bin
-		fmt.Printf("Moving bin %s to %s for alias %s\n", pathToBin, newPath, alias)
+		fmt.Printf("Creating new alias: %s\n", alias)
 		installToLocalBin(pathToBin, false, dryRun)
 	} else {
 		fmt.Printf("Error: Alias doesn't exist\nDid you mean to use 'create' to create a new alias?\nUsage: climb create <command> <script-path>")

--- a/src/execCmd/delete.go
+++ b/src/execCmd/delete.go
@@ -29,7 +29,7 @@ func Delete(alias string, dryRun bool) {
 	}
 	err = os.Remove(path)
 	if err != nil {
-		utils.NewEror("Failed to delete file\n", err)
+		utils.NewError("Failed to delete file\n", err)
 	}
 
 	fmt.Printf("Successfully deleted alias %s\n", alias)

--- a/src/utils/error.go
+++ b/src/utils/error.go
@@ -11,7 +11,7 @@ func FormatErrorMsg(err error) {
 }
 
 // Create and format a new error from a message and the error object
-func NewEror(msg string, err error) {
+func NewError(msg string, err error) {
 	var newErr = fmt.Errorf(msg, err)
 	FormatErrorMsg(newErr)
 }


### PR DESCRIPTION
There was a typo in `error.go`

`NewEror()` -> `NewError()`

Also removed the `newPath` var and log out in `createOrUpdate.go` as it is not the _actual_ path of where the bin is being moved to and might confuse users