### PR TITLE
feat: support relative path resolution

### DIFF
--- a/src/execCmd/createOrUpdate.go
+++ b/src/execCmd/createOrUpdate.go
@@ -30,14 +30,19 @@ func installToLocalBin(pathToBin string, alias string, isUpdate bool, dryRun boo
 		}
 	}
 
-	input, err := os.ReadFile(pathToBin)
+	absPath, err := filepath.Abs(pathToBin)
+	if err != nil {
+		utils.FormatErrorMsg(err)
+	}
+
+	input, err := os.ReadFile(absPath)
 	if err != nil {
 		utils.FormatErrorMsg(err)
 	}
 
 	destPath := filepath.Join(binDir, alias)
 	if dryRun == true {
-		fmt.Printf("DRY_RUN: Write file from %s to %s\n", pathToBin, destPath)
+		fmt.Printf("DRY_RUN: Write file from %s to %s\n", absPath, destPath)
 		return
 	}
 	err = os.WriteFile(destPath, input, 0755)


### PR DESCRIPTION
## Context

The tool accepts relative paths but doesn't convert them to absolute paths before copying. This could cause issues if the script is moved later or when the tool runs from a different directory.

This change eliminates this issue by making all paths absolute before copying the contents to the local bin.

This resolves issue #17 