### PR TITLE
fix: error formatting

### DIFF
--- a/src/execCmd/createOrUpdate.go
+++ b/src/execCmd/createOrUpdate.go
@@ -93,7 +93,7 @@ func Update(alias string, pathToBin string, dryRun bool) {
 func validatePathToBin(pathToBin string) {
 	fileInfo, err := os.Stat(pathToBin)
 	if err != nil {
-		utils.NewError("Error: file "+pathToBin+" is not executable", err)
+		utils.NewErrorFromMsg("Error: file " + pathToBin + " could not be found\n" + err.Error() + "\n")
 	}
 	if fileInfo.Mode().Perm()&0111 == 0 {
 		utils.NewErrorFromMsg("Error: file " + pathToBin + " is not executable")

--- a/src/execCmd/delete.go
+++ b/src/execCmd/delete.go
@@ -29,7 +29,8 @@ func Delete(alias string, dryRun bool) {
 	}
 	err = os.Remove(path)
 	if err != nil {
-		utils.NewError("Failed to delete file\n", err)
+		fmt.Printf("Failed to delete command at path %s\n", path)
+		utils.FormatErrorMsg(err)
 	}
 
 	fmt.Printf("Successfully deleted alias %s\n", alias)

--- a/src/utils/error.go
+++ b/src/utils/error.go
@@ -6,18 +6,12 @@ import (
 )
 
 func FormatErrorMsg(err error) {
-	fmt.Print("Unexpected Error")
+	fmt.Print("Unexpected Error\n")
 	log.Fatal(err)
-}
-
-// Create and format a new error from a message and the error object
-func NewError(msg string, err error) {
-	var newErr = fmt.Errorf(msg, err)
-	FormatErrorMsg(newErr)
 }
 
 // Create and format a new Error from message without an error object
 func NewErrorFromMsg(msg string) {
-	var newErr = fmt.Errorf(msg, "")
-	FormatErrorMsg(newErr)
+	fmt.Print("Unexpected Error\n")
+	log.Fatal(msg)
 }


### PR DESCRIPTION
## Summary

Fixes issue #24 

For a script that doesn't exist (and so also isn't executable) the formatting merges the messages together without a \n

```bash
Unexpected Error2026/01/22 16:18:11 Error: file ./add-ssh-keys.sh is not executable%!(EXTRA *fs.PathError=stat ./add-ssh-keys.sh: no such file or directory)
```

Rather than expected

```bash
Unexpected Error
2026/01/22 16:18:11 Error: file ./add-ssh-keys.sh is not executable
%!(EXTRA *fs.PathError=stat ./add-ssh-keys.sh: no such file or directory)
```

I have also removed the utils.NewError() fn as I don't think it's needed.