### PR TITLE
fix: Failing installastion, creates missing dir, fixes go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module climb
 
-go 1.25.5
+go 1.23

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,5 +14,10 @@ chmod +x ./scripts/setUpPath.sh
 # Apply changes to ~/.zshrc
 touch ~/.zshrc
 
-# Create command for climb CLI
-./bin/climb create climb ./bin/climb
+# Create or update command for climb CLI
+if command -v climb >/dev/null 2>&1; then
+ echo "Updating existing climb installation..."
+ ./bin/climb update climb ./bin/climb
+else
+ ./bin/climb create climb ./bin/climb
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -e
 
 # Build executable
+mkdir -p ./bin
 go build -o ./bin/climb
 
 # Grant execute perms to path set up script


### PR DESCRIPTION
Noticed that installation was failing silently on a fresh clone (on `go build -o ./bin/climb`). Because the `./bin` directory was not present (go don't create that automatically).

Fixed by creating that dir if it's not yet present (that's what `-p`) does. Also enabled `set -e`, so the install script fails fast on errors (previously it could continue after a failed build).
...Which then meant I had to fix your invalid go version in the `go.mod` - format should just be MAJOR.MINOR (don't include patch). All working smoothly now :)

Edit: Also i made the install idempotent, so it won't error if alias already exist, by checking it first, and using `alias update` instead of `alias create`


---

Btw, you could/should improve this, with pipefail and then trap to catch errors. That way, if there ever is an error, you'll get proper error messaging. E.g..

```bash
set -Eeuo pipefail

trap 'echo "❌ Error on line $LINENO. Aborting." >&2' ERR

...

command -v go >/dev/null 2>&1 || {
  echo "❌ Go is not installed or not on PATH." >&2
  exit 1
}

```