### PR TITLE
fix: don't allow deletion of core commands

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,15 @@
 
 `climb` is a CLI tool that makes your local scripts and binaries globally available by creating aliases that can be called from anywhere in your terminal. It manages scripts by installing them to your local bin directory (`~/.local/bin` on Unix-like systems or `%LOCALAPPDATA%\Microsoft\WindowsApps` on Windows).
 
+### Key Features
+
+- **Easy alias management:** Create, update, and delete command aliases with simple commands
+- **Safety-first design:** Only allows deletion of commands created by `climb` to prevent accidental removal of system commands
+- **Dry-run mode:** Preview changes before committing them with the `--dry-run` flag
+- **Path flexibility:** Works with both relative and absolute paths to your scripts
+- **Validation:** Automatic validation of alias names and script paths
+- **Cross-platform:** Supports Unix-like systems (macOS, Linux) and Windows
+
 ## Installation
 
 See the [README](../README.md) for installation instructions.
@@ -101,9 +110,19 @@ climb delete hello
 
 **Behavior:**
 - Looks up the alias in your PATH
+- Verifies the command exists in your local bin directory (safety check)
+- Prevents deletion of external/system commands
 - Displays the file location
 - Prompts for confirmation before deletion
 - Removes the file from your local bin directory
+
+**Safety Features:**
+- Only allows deletion of commands that were created by `climb`
+- Refuses to delete system or external commands to prevent accidental removal
+- If you try to delete a command that isn't in the climb bin directory, you'll see an error:
+  ```
+  Error: Command 'myalias' not found in bin directory - cannot safely delete
+  ```
 
 **Interactive Prompt:**
 ```
@@ -271,6 +290,14 @@ climb create myapp ~/bin/myapp
 - When deleting, the alias wasn't found
 - The alias may have already been deleted or never existed
 
+**"Command not found in bin directory - cannot safely delete"**
+- You attempted to delete a command that wasn't created by `climb`
+- This is a safety feature to prevent accidental deletion of system commands
+- Only commands in your local bin directory (created by `climb`) can be deleted
+- Verify the command exists in:
+  - Unix-like systems: `~/.local/bin`
+  - Windows: `%LOCALAPPDATA%\Microsoft\WindowsApps`
+
 ---
 
 ## Tips
@@ -357,3 +384,16 @@ The WindowsApps directory is typically already in PATH.
 1. Ensure the script has proper shebang line
 2. If the script uses relative paths internally, make them absolute or run the script from the expected directory
 3. Verify script dependencies are available globally
+
+**Cannot delete an alias with error "not found in bin directory":**
+1. This is a safety feature - `climb` only allows deletion of commands it created
+2. Verify the alias is in your local bin directory:
+   ```bash
+   ls -la ~/.local/bin/<alias>
+   ```
+3. Check that the alias path matches your local bin location:
+   ```bash
+   which <alias>
+   ```
+4. If the command is in a different location (system command, homebrew, etc.), it cannot be deleted with `climb`
+5. To delete such commands, use your system's package manager or remove them manually with `rm`

--- a/src/execCmd/createOrUpdate.go
+++ b/src/execCmd/createOrUpdate.go
@@ -93,7 +93,7 @@ func Update(alias string, pathToBin string, dryRun bool) {
 func validatePathToBin(pathToBin string) {
 	fileInfo, err := os.Stat(pathToBin)
 	if err != nil {
-		utils.NewError("Error: file "+pathToBin+" is not executable", err)
+		utils.NewErrorFromMsg("Error: file " + pathToBin + " could not be found\n" + err.Error() + "\n")
 	}
 	if fileInfo.Mode().Perm()&0111 == 0 {
 		utils.NewErrorFromMsg("Error: file " + pathToBin + " is not executable")

--- a/src/execCmd/createOrUpdate.go
+++ b/src/execCmd/createOrUpdate.go
@@ -5,26 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
-func getBinDir(home string) string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(home, "AppData", "local", "Microsoft", "WindowsApps")
-	}
-	return filepath.Join(home, ".local", "bin")
-}
-
 func installToLocalBin(pathToBin string, alias string, isUpdate bool, dryRun bool) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		utils.FormatErrorMsg(err)
-	}
-
-	var binDir = getBinDir(home)
+	var binDir = utils.GetBinDir()
 
 	if isUpdate == false {
-		err = os.MkdirAll(binDir, 0755)
+		err := os.MkdirAll(binDir, 0755)
 		if err != nil {
 			utils.FormatErrorMsg(err)
 		}

--- a/src/execCmd/delete.go
+++ b/src/execCmd/delete.go
@@ -29,7 +29,8 @@ func Delete(alias string, dryRun bool) {
 	}
 	err = os.Remove(path)
 	if err != nil {
-		utils.NewError("Failed to delete file\n", err)
+		fmt.Printf("Failed to delete command at path %s\n", path)
+		utils.FormatErrorMsg(err)
 	}
 
 	fmt.Printf("Successfully deleted alias %s\n", alias)

--- a/src/execCmd/delete.go
+++ b/src/execCmd/delete.go
@@ -5,20 +5,33 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
+func isCmdInBinDir(path string) bool {
+	var binPath = utils.GetBinDir()
+	if strings.HasPrefix(path, binPath) {
+		return true
+	}
+	return false
+}
+
 func Delete(alias string, dryRun bool) {
+	path, err := exec.LookPath(alias)
+	if err != nil {
+		utils.NewErrorFromMsg("Command '" + alias + "' not found in PATH")
+	}
+
+	if !isCmdInBinDir(path) {
+		utils.NewErrorFromMsg("Command '" + alias + "' not found in bin directory - cannot safely delete")
+	}
+
 	var msg = "Are you sure you want to delete alias: " + alias + "?"
 	var shouldDelete = utils.ShouldOverrideFile(msg)
 
 	if shouldDelete == false {
 		fmt.Printf("Deletion of alias %s has been aborted\n", alias)
 		return
-	}
-
-	path, err := exec.LookPath(alias)
-	if err != nil {
-		utils.NewErrorFromMsg("Command '" + alias + "' not found in PATH")
 	}
 
 	fmt.Printf("Found command at: %s\n", path)

--- a/src/utils/error.go
+++ b/src/utils/error.go
@@ -6,18 +6,12 @@ import (
 )
 
 func FormatErrorMsg(err error) {
-	fmt.Print("Unexpected Error")
+	fmt.Print("Unexpected Error\n")
 	log.Fatal(err)
-}
-
-// Create and format a new error from a message and the error object
-func NewError(msg string, err error) {
-	var newErr = fmt.Errorf(msg, err)
-	FormatErrorMsg(newErr)
 }
 
 // Create and format a new Error from message without an error object
 func NewErrorFromMsg(msg string) {
-	var newErr = fmt.Errorf(msg, "")
-	FormatErrorMsg(newErr)
+	fmt.Print("Unexpected Error\n")
+	log.Fatal(msg)
 }

--- a/src/utils/paths.go
+++ b/src/utils/paths.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func GetBinDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if runtime.GOOS == "windows" {
+		return filepath.Join(home, "AppData", "local", "Microsoft", "WindowsApps")
+	}
+	return filepath.Join(home, ".local", "bin")
+}


### PR DESCRIPTION
## Summary

Fixes #29 

Previously the delete command would allow users to delete commands that were not added to the local bin dir where climb writes new commands to, which allowed users to delete commands like `bash` and `curl`

Climb now checks that the file path is in the local bin directory before deleting commands.

```bash
./bin/climb delete curl
Unexpected Error
2026/01/26 18:51:44 Command 'curl' not found in bin directory - cannot safely delete
```