### PR TITLE
feat: support symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Commands:
 
 Options:
   --dry-run                     Preview changes without modifying files
+  --symlink                     Create a symlink instead of copying a script/binary
 ```
 
 ## Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@
 ### Key Features
 
 - **Easy alias management:** Create, update, and delete command aliases with simple commands
+- **Symlink support:** Create a symlink instead of copying a script/binary
 - **Safety-first design:** Only allows deletion of commands created by `climb` to prevent accidental removal of system commands
 - **Dry-run mode:** Preview changes before committing them with the `--dry-run` flag
 - **Path flexibility:** Works with both relative and absolute paths to your scripts
@@ -16,6 +17,33 @@
 ## Installation
 
 See the [README](../README.md) for installation instructions.
+
+---
+
+## Symlinks vs Copy
+
+By default, `climb` copies your script to `~/.local/bin/`. Use the `--symlink` flag to create a symbolic link instead:
+
+```bash
+climb create myalias /path/to/script.sh        # Copy (default)
+climb create --symlink myalias /path/to/script.sh  # Symlink
+```
+
+**Copy Mode:**
+- Independent copy of your script
+- Works if original is moved or deleted
+- Changes to original don't affect alias
+
+**Symlink Mode:**
+- Points to original script
+- Changes to original are reflected automatically
+- Breaks if original is moved or deleted
+
+**Switch between modes using update:**
+```bash
+climb --symlink update myalias /path/to/script.sh  # Copy → Symlink
+climb update myalias /path/to/script.sh            # Symlink → Copy
+```
 
 ---
 
@@ -152,6 +180,7 @@ Commands:
 
 Options:
   --dry-run                     Preview changes without modifying files
+  --symlink                     Create a symlink instead of copying a script/binary
 ```
 
 ---

--- a/main.go
+++ b/main.go
@@ -8,10 +8,11 @@ import (
 
 func main() {
 	dryRun := flag.Bool("dry-run", false, "When enabled no files are modified, created or deleted")
+	useSymlink := flag.Bool("symlink", false, "When enabled symlinks are created instead of copies")
 
 	flag.Parse()
 
 	var args = flag.Args()
 
-	cli.Cmd(args, *dryRun)
+	cli.Cmd(args, *dryRun, *useSymlink)
 }

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -5,7 +5,7 @@ import (
 	"climb/src/utils"
 )
 
-func Cmd(args []string, dryRun bool) {
+func Cmd(args []string, dryRun bool, useSymlink bool) {
 	strippedArgs := utils.StripFlagsFromArgs(args)
 	utils.ValidateArgs(strippedArgs)
 
@@ -16,8 +16,8 @@ func Cmd(args []string, dryRun bool) {
 	case "delete":
 		execCmd.Delete(alias, dryRun)
 	case "create":
-		execCmd.Create(alias, args[2], dryRun)
+		execCmd.Create(alias, args[2], dryRun, useSymlink)
 	case "update":
-		execCmd.Update(alias, args[2], dryRun)
+		execCmd.Update(alias, args[2], dryRun, useSymlink)
 	}
 }

--- a/src/execCmd/createOrUpdate.go
+++ b/src/execCmd/createOrUpdate.go
@@ -7,14 +7,12 @@ import (
 	"path/filepath"
 )
 
-func installToLocalBin(pathToBin string, alias string, isUpdate bool, dryRun bool) {
+func installToLocalBin(pathToBin string, alias string, dryRun bool, useSymlink bool) {
 	var binDir = utils.GetBinDir()
 
-	if isUpdate == false {
-		err := os.MkdirAll(binDir, 0755)
-		if err != nil {
-			utils.FormatErrorMsg(err)
-		}
+	err := os.MkdirAll(binDir, 0755)
+	if err != nil {
+		utils.FormatErrorMsg(err)
 	}
 
 	absPath, err := filepath.Abs(pathToBin)
@@ -22,16 +20,32 @@ func installToLocalBin(pathToBin string, alias string, isUpdate bool, dryRun boo
 		utils.FormatErrorMsg(err)
 	}
 
+	destPath := filepath.Join(binDir, alias)
+
+	if useSymlink {
+		if dryRun {
+			fmt.Printf("DRY_RUN: Create symlink from %s to %s\n", destPath, absPath)
+			return
+		}
+		err := utils.CreateSymlink(absPath, destPath)
+		if err != nil {
+			utils.FormatErrorMsg(err)
+		}
+		fmt.Printf("Successfully created symlink: %s\n", destPath)
+		return
+	}
+
+	// Default: create copy
 	input, err := os.ReadFile(absPath)
 	if err != nil {
 		utils.FormatErrorMsg(err)
 	}
 
-	destPath := filepath.Join(binDir, alias)
-	if dryRun == true {
+	if dryRun {
 		fmt.Printf("DRY_RUN: Write file from %s to %s\n", absPath, destPath)
 		return
 	}
+
 	err = os.WriteFile(destPath, input, 0755)
 	if err != nil {
 		utils.FormatErrorMsg(err)
@@ -40,41 +54,60 @@ func installToLocalBin(pathToBin string, alias string, isUpdate bool, dryRun boo
 	fmt.Printf("Successfully installed to: %s\n", destPath)
 }
 
-func CreateOrUpdate(alias string, pathToBin string, canOverrideExisting bool, dryRun bool) {
+func CreateOrUpdate(alias string, pathToBin string, isUpdate bool, dryRun bool, useSymlink bool) {
 	if !utils.IsValidAliasName(alias) {
 		utils.NewErrorFromMsg("Error: Invalid alias name '" + alias + "'. Alias must start with a letter or underscore, and contain only alphanumeric characters, underscores, and hyphens")
 	}
 	validatePathToBin(pathToBin)
 
-	if utils.AliasExists(alias) {
-		if canOverrideExisting == true {
-			// Update alias for new bin
-			var msg = "Do you want to override alias: " + alias
+	binDir := utils.GetBinDir()
+	destPath := filepath.Join(binDir, alias)
 
-			if utils.ShouldOverrideFile(msg) == true {
-				installToLocalBin(pathToBin, alias, true, dryRun)
-			} else {
-				fmt.Printf("Overwrite of command %s with binary at %s has been aborted\n", alias, pathToBin)
-			}
-		} else {
+	if utils.AliasExists(alias) {
+		if !isUpdate {
+			// Create command but alias exists
 			fmt.Printf("Error: Alias already exists\nDid you mean to use 'update' to update an existing alias?\nUsage: climb update <command> <script-path>")
 			os.Exit(1)
 		}
-	} else if canOverrideExisting == false {
-		// Create new alias for bin
-		fmt.Printf("Creating new alias: %s\n", alias)
-		installToLocalBin(pathToBin, alias, false, dryRun)
-	} else {
+
+		isCurrentSymlink := utils.IsSymlink(destPath)
+		if isCurrentSymlink != useSymlink {
+			// Switching link types
+			typeFrom := "symlink"
+			typeTo := "copy"
+			if useSymlink {
+				typeFrom = "copy"
+				typeTo = "symlink"
+			}
+			fmt.Printf("Alias currently exists as a %s. Converting to %s.\n", typeFrom, typeTo)
+		}
+
+		var msg = "Do you want to override alias: " + alias
+		if utils.ShouldOverrideFile(msg) {
+			if !dryRun {
+				os.Remove(destPath)
+			}
+			installToLocalBin(pathToBin, alias, dryRun, useSymlink)
+		} else {
+			fmt.Printf("Overwrite of command %s has been aborted\n", alias)
+		}
+	} else if isUpdate {
+		// Update command but alias doesn't exist
 		fmt.Printf("Error: Alias doesn't exist\nDid you mean to use 'create' to create a new alias?\nUsage: climb create <command> <script-path>")
+		os.Exit(1)
+	} else {
+		// Create new alias
+		fmt.Printf("Creating new alias: %s\n", alias)
+		installToLocalBin(pathToBin, alias, dryRun, useSymlink)
 	}
 }
 
-func Create(alias string, pathToBin string, dryRun bool) {
-	CreateOrUpdate(alias, pathToBin, false, dryRun)
+func Create(alias string, pathToBin string, dryRun bool, useSymlink bool) {
+	CreateOrUpdate(alias, pathToBin, false, dryRun, useSymlink)
 }
 
-func Update(alias string, pathToBin string, dryRun bool) {
-	CreateOrUpdate(alias, pathToBin, true, dryRun)
+func Update(alias string, pathToBin string, dryRun bool, useSymlink bool) {
+	CreateOrUpdate(alias, pathToBin, true, dryRun, useSymlink)
 }
 
 func validatePathToBin(pathToBin string) {

--- a/src/utils/flags.go
+++ b/src/utils/flags.go
@@ -8,6 +8,7 @@ func getFlags() map[string]struct{} {
 	flags := make(map[string]struct{})
 
 	flags["dry-run"] = struct{}{}
+	flags["symlink"] = struct{}{}
 
 	return flags
 }

--- a/src/utils/symlinks.go
+++ b/src/utils/symlinks.go
@@ -1,0 +1,15 @@
+package utils
+
+import "os"
+
+func CreateSymlink(source, target string) error {
+	return os.Symlink(source, target)
+}
+
+func IsSymlink(path string) bool {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink == os.ModeSymlink
+}

--- a/src/utils/validateArgs.go
+++ b/src/utils/validateArgs.go
@@ -23,6 +23,7 @@ func usage() {
 	fmt.Println("  help                          Show this help message")
 	fmt.Println("\nOptions:")
 	fmt.Println("  --dry-run                     Preview changes without modifying files")
+	fmt.Println("  --symlink                     Create a symlink instead of copying a script/binary")
 }
 
 func ValidateArgs(args []string) {


### PR DESCRIPTION
## Summary

Closes #30, #12 

Adds support for symlinks with `--symlink` flag for `create` and `update` commands (delete works the same way)

When updating a command with `--symlink` enabled, if the command already exists with a hard copy - the hard copy is replaced by a new symlink (and vice versa)

```bash
./bin/climb --symlink create sym ./bin/climb
Creating new alias: sym
Successfully created symlink: /Users/admin/.local/bin/sym
````